### PR TITLE
Email confirmations

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -64,6 +64,14 @@ misunderstandings and openness about decisions, refer to the following.
   opt-out, we can ensure to some degree that mistakes made will not result in
   clearly non-consensual communication.
 
+* **What if we edit consent definitions?** Well, apart from being fraudulent,
+  it's hard to guard people from changing consent. If you change something of
+  real meaning, you should ask for consent again. But this project doesn't seek
+  to support the dark pattern of companies continuously updating their consent
+  and telling users that "by continuing to use this service, you consent to the
+  below thousand lines of crap you don't have time to read".
+
+
 Issues are welcomed with the tag ``question`` to verify, challenge elaborate or
 add to this list.
 

--- a/README.rst
+++ b/README.rst
@@ -160,6 +160,11 @@ To use unsubscribe views, add this to your project's ``urls.py``:
       path('consent/', include('django_consent.urls')),
   ]
 
+If you want to be able to send out confirmation emails or otherwise email your
+users from management scripts and likewise, you need to configure
+``settings.SITE_ID = n`` to ensure that a correct default domain is guessed in
+the absence of an active HTTP request.
+
 
 Development
 -----------

--- a/README.rst
+++ b/README.rst
@@ -64,12 +64,13 @@ misunderstandings and openness about decisions, refer to the following.
   opt-out, we can ensure to some degree that mistakes made will not result in
   clearly non-consensual communication.
 
-* **What if we edit consent definitions?** Well, apart from being fraudulent,
-  it's hard to guard people from changing consent. If you change something of
-  real meaning, you should ask for consent again. But this project doesn't seek
-  to support the dark pattern of companies continuously updating their consent
-  and telling users that "by continuing to use this service, you consent to the
-  below thousand lines of crap you don't have time to read".
+* **What if we edit consent definitions?** This application is set up to send a
+  copy of what the user consented to via email. If you later change something of
+  real meaning in your own copy, you should ask for consent again. So ideally,
+  you would create a new consent object in the database. This project doesn't
+  seek to support the dark pattern of companies continuously updating their
+  consent and telling users that "by continuing to use this service, you consent
+  to the below thousand lines of legal lingo that you don't have time to read".
 
 
 Issues are welcomed with the tag ``question`` to verify, challenge elaborate or

--- a/demo/demo/settings.py
+++ b/demo/demo/settings.py
@@ -120,3 +120,5 @@ USE_TZ = True
 # https://docs.djangoproject.com/en/3.1/howto/static-files/
 
 STATIC_URL = "/static/"
+
+SITE_ID = 1

--- a/demo/demo/settings.py
+++ b/demo/demo/settings.py
@@ -36,8 +36,8 @@ INSTALLED_APPS = [
     "django.contrib.sessions",
     "django.contrib.messages",
     "django.contrib.staticfiles",
-    "django_consent",
     "demoapp",
+    "django_consent",
 ]
 
 MIDDLEWARE = [

--- a/demo/demoapp/static/css/demo.css
+++ b/demo/demoapp/static/css/demo.css
@@ -1,0 +1,60 @@
+body, html {
+    font-family: monospace;
+    margin: 0;
+    padding: 0;
+    font-size: 120%;
+}
+
+header, article, footer {
+    margin: 0 auto;
+}
+
+header {
+    background-color: #5500ab;
+    color: #fff;
+}
+
+.container {
+    margin: 0 auto;
+    max-width: 800px;
+    padding: 20px;
+}
+
+a, a:visited, a:active {
+    color: #fff;
+}
+
+td, th {
+    padding: 10px 0;
+}
+th {
+    text-align: left;
+    line-height: 40px;
+    vertical-align: top;
+    padding-right: 20px;
+}
+
+
+td input,
+td textarea {
+    width: 300px;
+}
+
+input[type=checkbox]
+{
+    width: auto;
+    margin-bottom: 5px;
+}
+
+input, textarea, select {
+    font-family: monospace;
+    font-size: 120%;
+    padding: 5px;
+}
+
+code {
+    border: 1px solid #ccc;
+    padding: 3px;
+    font-size: 80%;
+    background-color: #f8f8f8;
+}

--- a/demo/demoapp/templates/base.html
+++ b/demo/demoapp/templates/base.html
@@ -1,11 +1,14 @@
-{% load demotags %}
+{% load demotags static %}
 <html>
 <head>
 <title>Django Consent demo project</title>
+    <link rel="stylesheet" href="{% static "css/demo.css" %}" type="text/css">
+
 </head>
 <body>
 
 <header>
+<div class="container">
 <strong>Django Consent demo project</strong>
 
 <p>This project shows a couple of patterns for using Django Consent that you can use and adapt in your own project.</p>
@@ -14,12 +17,15 @@
 {% for source in sources %}
 <p><a href="{% url "demo:signup" source_id=source.id %}">Consent to {{ source.source_name }}</a></p>
 {% endfor %}
+</div>
 </header>
 
 <article>
+<div class="container">
 {% block demo_content %}
 
 {% endblock %}
+</div>
 </article>
 
 

--- a/demo/demoapp/templates/consent/base.html
+++ b/demo/demoapp/templates/consent/base.html
@@ -1,0 +1,15 @@
+{% extends "base.html" %}
+
+
+{% comment %}
+This part of the demo shows how you can overwrite consent/base.html in order to
+have your own main template apply to django-consent's built-in templates.
+
+Simply place the consent_content block in the appropriate location.
+{% endcomment %}
+
+{% block demo_content %}
+    {% block consent_content %}
+
+    {% endblock %}
+{% endblock %}

--- a/demo/demoapp/templates/signup.html
+++ b/demo/demoapp/templates/signup.html
@@ -5,7 +5,7 @@
 <h1>Sign up for {{ consent_source.source_name }}</h1>
 
 <p>
-The below form is an example of inheriting from <code>SignupView</code> which
+The below form is an example of inheriting from <code>ConsentCreateView</code> which
 uses the <code>EmailConsentForm</code>. In your own application, you can make
 similar patterns and it's encouraged that you extend one of these two classes.
 </p>

--- a/demo/demoapp/templates/signup.html
+++ b/demo/demoapp/templates/signup.html
@@ -4,13 +4,23 @@
 
 <h1>Sign up for {{ consent_source.source_name }}</h1>
 
+<p>
+The below form is an example of inheriting from <code>SignupView</code> which
+uses the <code>EmailConsentForm</code>. In your own application, you can make
+similar patterns and it's encouraged that you extend one of these two classes.
+</p>
+
 <form method="POST">
 
     {% csrf_token %}
 
-    {{ form.as_p }}
+    <table>
+    {{ form.as_table }}
+    </table>
 
+    <p>
     <button type="submit">Send</button>
+    </p>
 
 </form>
 

--- a/demo/demoapp/urls.py
+++ b/demo/demoapp/urls.py
@@ -10,12 +10,12 @@ urlpatterns = [
     path("", views.Index.as_view(), name="index"),
     path(
         "signup/<int:source_id>/",
-        views.SignupView.as_view(),
+        views.ConsentCreateView.as_view(),
         name="signup",
     ),
     path(
         "signup/<int:source_id>/confirmation/",
-        views.SignupConfirmationView.as_view(),
+        views.ConsentConfirmationSentView.as_view(),
         name="signup_confirmation",
     ),
 ]

--- a/demo/demoapp/views.py
+++ b/demo/demoapp/views.py
@@ -1,14 +1,14 @@
 from django.urls.base import reverse
 from django.views.generic.base import TemplateView
-from django_consent.views import SignupConfirmationView
-from django_consent.views import SignupView
+from django_consent.views import ConsentConfirmationSentView
+from django_consent.views import ConsentCreateView
 
 
 class Index(TemplateView):
     template_name = "base.html"
 
 
-class SignupView(SignupView):
+class ConsentCreateView(ConsentCreateView):
     template_name = "signup.html"
 
     def get_success_url(self):
@@ -17,5 +17,5 @@ class SignupView(SignupView):
         )
 
 
-class SignupConfirmationView(SignupConfirmationView):
+class ConsentConfirmationSentView(ConsentConfirmationSentView):
     pass

--- a/src/django_consent/emails.py
+++ b/src/django_consent/emails.py
@@ -1,0 +1,60 @@
+from django.conf import settings
+from django.contrib import messages
+from django.contrib.sites.shortcuts import get_current_site
+from django.core.mail.message import EmailMessage
+from django.template import loader
+from django.utils.translation import gettext as _
+
+
+class BaseEmail(EmailMessage):
+    """
+    Base class for sending emails
+    """
+
+    template = "consent/email/base.txt"
+    subject_template = "consent/email/base_subject.txt"
+
+    def __init__(self, request, *args, **kwargs):
+        self.context = kwargs.pop("context", {})
+        self.user = kwargs.pop("user", None)
+        if self.user:
+            kwargs["to"] = [self.user.email]
+            self.context["user"] = self.user
+            self.context["recipient_name"] = self.user.get_full_name()
+        else:
+            self.context["recipient_name"] = kwargs.pop("recipient_name", None)
+
+        super(BaseEmail, self).__init__(*args, **kwargs)
+        self.request = request
+        self.body = self.get_body()
+        self.subject = self.get_subject()
+
+    def get_context_data(self):
+        c = self.context
+        site = get_current_site(self.request)
+        c["request"] = self.request
+        c["domain"] = site.domain
+        c["site_name"] = site.name
+        c["protocol"] = "https" if not settings.DEBUG else "http"
+        return c
+
+    def get_body(self):
+        return loader.render_to_string(self.template, self.get_context_data())
+
+    def get_subject(self):
+        # Remember the .strip() as templates often have dangling newlines which
+        # are not accepted as subject lines
+        return loader.render_to_string(
+            self.subject_template, self.get_context_data()
+        ).strip()
+
+    def send_with_feedback(self, success_msg=None):
+        if not success_msg:
+            success_msg = _("Email successfully sent to {}".format(", ".join(self.to)))
+        try:
+            self.send(fail_silently=False)
+            messages.success(self.request, success_msg)
+        except RuntimeError:
+            messages.error(
+                self.request, _("Not sent, something wrong with the mail server.")
+            )

--- a/src/django_consent/emails.py
+++ b/src/django_consent/emails.py
@@ -21,8 +21,11 @@ class BaseEmail(EmailMessage):
             kwargs["to"] = [self.user.email]
             self.context["user"] = self.user
             self.context["recipient_name"] = self.user.get_full_name()
-        else:
-            self.context["recipient_name"] = kwargs.pop("recipient_name", None)
+
+        # Overwrite if recipient_name is set
+        self.context["recipient_name"] = kwargs.pop(
+            "recipient_name", self.context.get("recipient_name", None)
+        )
 
         super(BaseEmail, self).__init__(*args, **kwargs)
         self.request = request

--- a/src/django_consent/emails.py
+++ b/src/django_consent/emails.py
@@ -14,9 +14,10 @@ class BaseEmail(EmailMessage):
     template = "consent/email/base.txt"
     subject_template = "consent/email/base_subject.txt"
 
-    def __init__(self, request, *args, **kwargs):
+    def __init__(self, *args, **kwargs):
         self.context = kwargs.pop("context", {})
         self.user = kwargs.pop("user", None)
+        self.request = kwargs.pop("request", None)
         if self.user:
             kwargs["to"] = [self.user.email]
             self.context["user"] = self.user
@@ -28,7 +29,6 @@ class BaseEmail(EmailMessage):
         )
 
         super(BaseEmail, self).__init__(*args, **kwargs)
-        self.request = request
         self.body = self.get_body()
         self.subject = self.get_subject()
 
@@ -61,3 +61,23 @@ class BaseEmail(EmailMessage):
             messages.error(
                 self.request, _("Not sent, something wrong with the mail server.")
             )
+
+
+class ConfirmationNeededEmail(BaseEmail):
+    """
+    Email sent to confirm the validity of an email in connection to a consent
+    that was given.
+    """
+
+    template = "consent/email/confirmation.txt"
+    subject_template = "consent/email/confirmation_subject.txt"
+
+    def __init__(self, *args, **kwargs):
+
+        self.consent = kwargs.pop("consent")
+        super().__init__(*args, **kwargs)
+
+    def get_context_data(self):
+        c = super().get_context_data()
+        c["consent"] = self.consent
+        return c

--- a/src/django_consent/forms.py
+++ b/src/django_consent/forms.py
@@ -1,4 +1,5 @@
 from django import forms
+from django.utils.translation import gettext_lazy as _
 
 from . import models
 
@@ -16,6 +17,7 @@ class EmailConsentForm(forms.ModelForm):
     def __init__(self, *args, **kwargs):
         self.consent_source = kwargs.pop("consent_source")
         super().__init__(*args, **kwargs)
+        self.fields["consent_text"].initial = self.consent_source.definition
 
     email = forms.EmailField()
 
@@ -23,7 +25,9 @@ class EmailConsentForm(forms.ModelForm):
         widget=forms.Textarea(attrs={"disabled": True}), required=False
     )
 
-    confirmation = forms.BooleanField(required=True)
+    confirmation = forms.BooleanField(
+        required=True, help_text=_("I consent to the above")
+    )
 
     def save(self, commit=True):
         if not commit:

--- a/src/django_consent/models.py
+++ b/src/django_consent/models.py
@@ -8,6 +8,7 @@ from django.utils import timezone
 from django.utils.translation import gettext_lazy as _
 
 from . import emails
+from . import settings as consent_settings
 from . import utils
 
 
@@ -176,7 +177,7 @@ class UserConsent(models.Model):
 
     @property
     def confirm_token(self):
-        return utils.get_confirm_token(self)
+        return utils.get_consent_token(self, salt=consent_settings.CONFIRM_SALT)
 
 
 class EmailCampaign(models.Model):

--- a/src/django_consent/settings.py
+++ b/src/django_consent/settings.py
@@ -2,4 +2,9 @@ from django.conf import settings
 
 
 #: You can harden security by adding a different salt in your project's settings
-UNSUBSCRIBE_SALT = getattr(settings, "CONSENT_UNSUBSCRIBE_SALT", "django-consent")
+UNSUBSCRIBE_SALT = getattr(
+    settings, "CONSENT_UNSUBSCRIBE_SALT", "django-consent-unsubscribe"
+)
+
+#: You can harden security by adding a different salt in your project's settings
+CONFIRM_SALT = getattr(settings, "CONSENT_CONFIRM_SALT", "django-consent-confirm")

--- a/src/django_consent/templates/consent/email/base.txt
+++ b/src/django_consent/templates/consent/email/base.txt
@@ -1,4 +1,4 @@
-{% load i18n %}{% block intro %}{% blocktrans with user.get_full_name as name %}Dear {{ name }},{% endblocktrans %}{% endblock %}
+{% load i18n %}{% block intro %}{% blocktrans %}Dear {{ recipient_name }},{% endblocktrans %}{% endblock %}
 
 {% block body %}{% endblock %}
 

--- a/src/django_consent/templates/consent/email/base.txt
+++ b/src/django_consent/templates/consent/email/base.txt
@@ -1,4 +1,4 @@
-{% load i18n %}{% block intro %}{% blocktrans %}Dear {{ recipient_name }},{% endblocktrans %}{% endblock %}
+{% load i18n %}{% block intro %}{% blocktrans with recipient_name|default:_("user") as name %}Dear {{ name }},{% endblocktrans %}{% endblock %}
 
 {% block body %}{% endblock %}
 

--- a/src/django_consent/templates/consent/email/base.txt
+++ b/src/django_consent/templates/consent/email/base.txt
@@ -1,0 +1,8 @@
+{% load i18n %}{% block intro %}{% blocktrans with user.get_full_name as name %}Dear {{ name }},{% endblocktrans %}{% endblock %}
+
+{% block body %}{% endblock %}
+
+{% block signature %}{% trans "With kind regards," %}
+
+{{ site_name }}
+{{ protocol }}://{{ domain }}{% endblock %}

--- a/src/django_consent/templates/consent/email/base_subject.txt
+++ b/src/django_consent/templates/consent/email/base_subject.txt
@@ -1,0 +1,1 @@
+{% load i18n %}{% trans "Django Consent" %}

--- a/src/django_consent/templates/consent/email/confirm.txt
+++ b/src/django_consent/templates/consent/email/confirm.txt
@@ -1,9 +1,0 @@
-{% blocktrans %}Dear {{ name }},
-
-Someone, hopefully you, have consented to the following via our website:
-
-{{ consent_description }}
-
-To confirm that it is really you, please click this link:
-
-{{ confirm_link }}

--- a/src/django_consent/templates/consent/email/confirmation.txt
+++ b/src/django_consent/templates/consent/email/confirmation.txt
@@ -1,13 +1,11 @@
 {% extends "consent/email/base.txt" %}
 {% load i18n %}
 
-{% url "consent:consent_confirm" pk=consent.id token=consent.confirm_token as confirm_url %}
+{% block body %}{% url "consent:consent_confirm" pk=consent.id token=consent.confirm_token as confirm_url %}{% blocktrans with consent.definition as consent %}Someone, hopefully you, has consented to the following via our website:
 
-{% block body %}{% blocktrans %}Someone, hopefully you, has consented to the following via our website:
+{{ consent }}
 
-{{ consent.description }}
+To confirm that it is really you, please click this link:{% endblocktrans %}
 
-To confirm that it is really you, please click this link:
-
-{{ protocol }}://{{ domain }}{{ consent.confirm_token }}
-{% endblocktrans %}{% endblock %}
+{{ protocol }}://{{ domain }}{{ confirm_url }}
+{% endblock %}

--- a/src/django_consent/templates/consent/email/confirmation.txt
+++ b/src/django_consent/templates/consent/email/confirmation.txt
@@ -1,0 +1,13 @@
+{% extends "consent/email/base.txt" %}
+{% load i18n %}
+
+{% url "consent:consent_confirm" pk=consent.id token=consent.confirm_token as confirm_url %}
+
+{% block body %}{% blocktrans %}Someone, hopefully you, has consented to the following via our website:
+
+{{ consent.description }}
+
+To confirm that it is really you, please click this link:
+
+{{ protocol }}://{{ domain }}{{ consent.confirm_token }}
+{% endblocktrans %}{% endblock %}

--- a/src/django_consent/templates/consent/email/confirmation_subject.txt
+++ b/src/django_consent/templates/consent/email/confirmation_subject.txt
@@ -1,0 +1,1 @@
+{% load i18n %}{% trans "Your confirmation is needed" %}

--- a/src/django_consent/templates/consent/user/confirmation_received.html
+++ b/src/django_consent/templates/consent/user/confirmation_received.html
@@ -1,0 +1,9 @@
+{% extends "consent/base.html" %}
+{% load i18n %}
+{% block consent_content %}
+
+<h1>{% trans "Completed" %} ✅</h1>
+
+<p>{% trans "We have received a confirmation from you and verified the email address associated with your consent." %}</p>
+
+{% endblock %}

--- a/src/django_consent/templates/consent/user/confirmation_sent.html
+++ b/src/django_consent/templates/consent/user/confirmation_sent.html
@@ -1,0 +1,9 @@
+{% extends "consent/base.html" %}
+{% load i18n %}
+{% block consent_content %}
+
+<h1>{% trans "Confirmation sent" %} 📨</h1>
+
+<p>{% trans "Please check your inbox, as we have sent you a confirmation with a link that you need to click." %}</p>
+
+{% endblock %}

--- a/src/django_consent/urls.py
+++ b/src/django_consent/urls.py
@@ -9,17 +9,17 @@ app_name = "consent"
 urlpatterns = [
     path(
         "subscribe/<int:pk>/<str:token>/",
-        views.SubscribeConsentConfirmView.as_view(),
+        views.ConsentConfirmationReceiveView.as_view(),
         name="consent_confirm",
     ),
     path(
         "unsubscribe/<int:pk>/<str:token>/",
-        views.UnsubscribeConsentView.as_view(),
+        views.ConsentWithdrawView.as_view(),
         name="unsubscribe",
     ),
     path(
         "unsubscribe/<int:pk>/<str:token>/undo/",
-        views.UnsubscribeConsentUndoView.as_view(),
+        views.ConsentWithdrawUndoView.as_view(),
         name="unsubscribe_undo",
     ),
 ]

--- a/src/django_consent/utils.py
+++ b/src/django_consent/utils.py
@@ -9,38 +9,21 @@ def get_email_hash(email):
     return uuid.uuid3(uuid.NAMESPACE_URL, email)
 
 
-def get_unsubscribe_token(consent):
+def get_consent_token(consent, salt=consent_settings.UNSUBSCRIBE_SALT):
     """
     Returns a token (for a URL) which can be validated to unsubscribe from the
     supplied consent object.
     """
-    return signing.dumps(
-        str(consent.email_hash) + "," + str(consent.id),
-        salt=consent_settings.UNSUBSCRIBE_SALT,
-    )
+    return signing.dumps(str(consent.email_hash) + "," + str(consent.id), salt=salt)
 
 
-def get_confirm_token(consent):
-    """
-    Returns a token (for a URL) which can be validated to unsubscribe from the
-    supplied consent object.
-    """
-    return signing.dumps(
-        str(consent.email_hash) + "," + str(consent.id),
-        salt=consent_settings.CONFIRM_SALT,
-    )
-
-
-def validate_unsubscribe_token(token, consent):
+def validate_token(token, consent, salt=consent_settings.UNSUBSCRIBE_SALT):
     """
     Returns true/false according to whether the token validates for the consent
     object
     """
     try:
-        value = signing.loads(
-            token,
-            salt=consent_settings.UNSUBSCRIBE_SALT,
-        ).split(",")
+        value = signing.loads(token, salt=salt).split(",")
         return value[0] == str(consent.email_hash) and value[1] == str(consent.id)
     except (signing.BadSignature, IndexError):
         return False

--- a/src/django_consent/utils.py
+++ b/src/django_consent/utils.py
@@ -20,6 +20,17 @@ def get_unsubscribe_token(consent):
     )
 
 
+def get_confirm_token(consent):
+    """
+    Returns a token (for a URL) which can be validated to unsubscribe from the
+    supplied consent object.
+    """
+    return signing.dumps(
+        str(consent.email_hash) + "," + str(consent.id),
+        salt=consent_settings.CONFIRM_SALT,
+    )
+
+
 def validate_unsubscribe_token(token, consent):
     """
     Returns true/false according to whether the token validates for the consent

--- a/src/django_consent/views.py
+++ b/src/django_consent/views.py
@@ -11,7 +11,7 @@ from . import settings as consent_settings
 from . import utils
 
 
-class SignupView(CreateView):
+class ConsentCreateView(CreateView):
     """
     The view isn't part of urls.py but you can add it to your own project's
     url configuration if you want to use it.
@@ -48,21 +48,13 @@ class SignupView(CreateView):
         return ret_value
 
     def get_success_url(self):
+        """
+        This requires a project with a urlconf specifying a view with the name
+        'signup_confirmation'.
+        """
         return reverse(
             "signup_confirmation", kwargs={"source_id": self.consent_source.id}
         )
-
-
-class SignupConfirmationView(TemplateView):
-    """
-    Tells the user to check their inbox after a successful signup.
-
-    To mount it, add a source_id kwarg, for instance::
-
-        path("signup/<int:source_id>/confirmation/", SignupConfirmationView.as_view()),
-    """
-
-    template_name = "consent/user/confirm.html"
 
 
 class UserConsentActionView(DetailView):
@@ -95,11 +87,12 @@ class UserConsentActionView(DetailView):
         return c
 
 
-class UnsubscribeConsentView(UserConsentActionView):
+class ConsentWithdrawView(UserConsentActionView):
     """
-    Unsubscribes a user from a given consent.
+    Withdraws a consent. In the case of a newsletter, it unsubscribes a user
+    from receiving the newsletter.
 
-    Requires a valid link
+    Requires a valid link with a token.
     """
 
     template_name = "consent/user/unsubscribe/done.html"
@@ -110,9 +103,10 @@ class UnsubscribeConsentView(UserConsentActionView):
         consent.optout()
 
 
-class UnsubscribeConsentUndoView(UserConsentActionView):
+class ConsentWithdrawUndoView(UserConsentActionView):
     """
-    Unsubscribes a user from a given consent.
+    This is related to undoing withdrawal of consent in case that the user
+    clicked the wrong link.
 
     Requires a valid link
     """
@@ -123,14 +117,22 @@ class UnsubscribeConsentUndoView(UserConsentActionView):
         consent.optouts.all().delete()
 
 
-class SubscribeConsentConfirmView(UserConsentActionView):
+class ConsentConfirmationReceiveView(UserConsentActionView):
     """
     Marks a consent as confirmed, this is important for items that require a
     confirmed email address.
     """
 
-    template_name = "consent/user/confirm.html"
+    template_name = "consent/user/confirmation_received.html"
     token_salt = consent_settings.CONFIRM_SALT
 
     def action(self, consent):
         consent.confirm()
+
+
+class ConsentConfirmationSentView(TemplateView):
+    """
+    Informs a user that their confirmation has been sent
+    """
+
+    template_name = "consent/user/confirmation_sent.html"

--- a/src/django_consent/views.py
+++ b/src/django_consent/views.py
@@ -41,6 +41,12 @@ class SignupView(CreateView):
         c["consent_source"] = self.consent_source
         return c
 
+    def form_valid(self, form):
+        ret_value = super().form_valid(form)
+        consent = self.object
+        consent.email_confirmation(request=self.request)
+        return ret_value
+
     def get_success_url(self):
         return reverse(
             "signup_confirmation", kwargs={"source_id": self.consent_source.id}

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -39,3 +39,5 @@ MIDDLEWARE = [
 ]
 
 SECRET_KEY = "this is a test"
+
+EMAIL_BACKEND = "django.core.mail.backends.locmem.EmailBackend"

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -41,3 +41,5 @@ MIDDLEWARE = [
 SECRET_KEY = "this is a test"
 
 EMAIL_BACKEND = "django.core.mail.backends.locmem.EmailBackend"
+
+SITE_ID = 1

--- a/tests/test_emails.py
+++ b/tests/test_emails.py
@@ -1,13 +1,37 @@
 import pytest
+from django.contrib.messages.storage.fallback import FallbackStorage
 from django.contrib.sites.models import Site
 from django.core import mail
+from django.core.mail.backends.base import BaseEmailBackend
 from django_consent import emails
 from django_consent import models
 
 
+class FailBackend(BaseEmailBackend):
+    """
+    This backend loves failing :)
+    """
+
+    def send_messages(self, messages):
+        raise RuntimeError("I blow up 🤯")
+
+
 @pytest.mark.django_db
 def test_base(user_consent, rf):
+    """
+    This does a pretty basic test, and should be split up a bit.
+
+    We should cover some more cases, as we cannot say for sure yet if we know
+    for instance the name of the recipient.
+    """
     request = rf.get("/")
+
+    # Add messages and session to request object
+    # https://stackoverflow.com/questions/23861157/how-do-i-setup-messaging-and-session-middleware-in-a-django-requestfactory-durin
+    setattr(request, "session", "session")
+    messages = FallbackStorage(request)
+    setattr(request, "_messages", messages)
+
     # Because the default Site object uses example.com and a request object
     # from django RequestFactory generates testserver
     Site.objects.all().update(domain=request.get_host())
@@ -16,3 +40,15 @@ def test_base(user_consent, rf):
     email.send()
     assert len(mail.outbox) == 1
     assert mail.outbox[0].subject == "Django Consent"
+
+    email.send_with_feedback()
+    assert len(mail.outbox) == 2
+
+    email.connection = FailBackend()
+    email.send_with_feedback()
+    assert len(mail.outbox) == 2  # No increment expected
+
+    email = emails.BaseEmail(request, user=user, recipient_name="test person")
+    email.send()
+    assert len(mail.outbox) == 3
+    assert "test person" in mail.outbox[-1].body

--- a/tests/test_emails.py
+++ b/tests/test_emails.py
@@ -1,0 +1,18 @@
+import pytest
+from django.contrib.sites.models import Site
+from django.core import mail
+from django_consent import emails
+from django_consent import models
+
+
+@pytest.mark.django_db
+def test_base(user_consent, rf):
+    request = rf.get("/")
+    # Because the default Site object uses example.com and a request object
+    # from django RequestFactory generates testserver
+    Site.objects.all().update(domain=request.get_host())
+    user = models.UserConsent.objects.all().order_by("?")[0].user
+    email = emails.BaseEmail(request, user=user)
+    email.send()
+    assert len(mail.outbox) == 1
+    assert mail.outbox[0].subject == "Django Consent"

--- a/tests/test_emails.py
+++ b/tests/test_emails.py
@@ -3,6 +3,7 @@ from django.contrib.messages.storage.fallback import FallbackStorage
 from django.contrib.sites.models import Site
 from django.core import mail
 from django.core.mail.backends.base import BaseEmailBackend
+from django.urls import reverse
 from django_consent import emails
 from django_consent import models
 
@@ -59,4 +60,17 @@ def test_confirm(user_consent):
     consent = models.UserConsent.objects.filter(email_confirmed=False).order_by("?")[0]
     consent.email_confirmation(request=None)
     assert len(mail.outbox) == 1
+
+    # Assuming only one site exists
+    first_site = Site.objects.all()[0]
+
+    expected_url = "{}{}".format(
+        first_site,
+        reverse(
+            "consent:consent_confirm",
+            kwargs={"pk": consent.pk, "token": consent.confirm_token},
+        ),
+    )
+
     assert "Your confirmation is needed" in mail.outbox[-1].subject
+    assert expected_url in mail.outbox[-1].body

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -2,6 +2,7 @@ import pytest
 from django.contrib.auth import get_user_model
 from django.urls import reverse
 from django_consent import models
+from django_consent import settings as consent_settings
 from django_consent import utils
 
 from .fixtures import get_random_email
@@ -109,7 +110,9 @@ def test_unsubscribe(client, user_consent, create_user):
         "consent:unsubscribe",
         kwargs={
             "pk": consent.id,
-            "token": utils.get_unsubscribe_token(consent),
+            "token": utils.get_consent_token(
+                consent, salt=consent_settings.UNSUBSCRIBE_SALT
+            ),
         },
     )
 
@@ -133,7 +136,9 @@ def test_unsubscribe_undo(client, user_consent, create_user):
         "consent:unsubscribe_undo",
         kwargs={
             "pk": consent.id,
-            "token": utils.get_unsubscribe_token(consent),
+            "token": utils.get_consent_token(
+                consent, salt=consent_settings.UNSUBSCRIBE_SALT
+            ),
         },
     )
 
@@ -174,7 +179,9 @@ def test_consent_confirm(client, user_consent, create_user):
         "consent:consent_confirm",
         kwargs={
             "pk": consent.id,
-            "token": utils.get_unsubscribe_token(consent),
+            "token": utils.get_consent_token(
+                consent, salt=consent_settings.CONFIRM_SALT
+            ),
         },
     )
 

--- a/tests/urls.py
+++ b/tests/urls.py
@@ -5,15 +5,15 @@ It is not used by installed instances of this app.
 """
 from django.urls import include
 from django.urls import path
-from django_consent.views import SignupConfirmationView
-from django_consent.views import SignupView
+from django_consent.views import ConsentConfirmationSentView
+from django_consent.views import ConsentCreateView
 
 urlpatterns = [
     path("foo/", include("django_consent.urls")),
-    path("signup/<int:source_id>/", SignupView.as_view(), name="signup"),
+    path("signup/<int:source_id>/", ConsentCreateView.as_view(), name="signup"),
     path(
         "signup/<int:source_id>/confirmation/",
-        SignupConfirmationView.as_view(),
+        ConsentConfirmationSentView.as_view(),
         name="signup_confirmation",
     ),
     path("consent/", include("django_consent.urls")),


### PR DESCRIPTION
Fixes #9 

Ensures that no potential holes are found by generating unsubscription and confirmation tokens the same way.

TODO:

* [x] Demo project for developing and testing UX
* [x] Post-confirmation page, the "we have received your confirmation" step.
* [x] Testing contents of email

Demo project now looks like this

![image](https://user-images.githubusercontent.com/374612/110711907-99fc6d00-8200-11eb-985b-85266f81b026.png)
