### PR TITLE
Adding new views for undoing all consent associated with an email

### DIFF
--- a/src/django_consent/models.py
+++ b/src/django_consent/models.py
@@ -80,10 +80,6 @@ class UserConsent(models.Model):
     email_confirmed = models.BooleanField(default=False)
     email_hash = models.UUIDField()
 
-    @property
-    def email(self):
-        return self.user.email
-
     def email_confirmation(self, request=None):
         """
         Sends a confirmation email if necessary
@@ -143,14 +139,14 @@ class UserConsent(models.Model):
                 consent_create_kwargs["email_confirmation_requested"] = timezone.now()
         return cls.objects.create(source=source, user=user, **consent_create_kwargs)
 
-    def optout(self):
+    def optout(self, is_everything=False):
         """
         Ensures that user is opted out of this consent.
         """
         return EmailOptOut.objects.get_or_create(
             user=self.user,
             consent=self,
-            is_everything=False,
+            is_everything=is_everything,
         )[0]
 
     def confirm(self):
@@ -174,6 +170,10 @@ class UserConsent(models.Model):
             self.optouts.all().exists()
             or self.user.email_optouts.filter(is_everything=True).exists()
         )
+
+    @property
+    def email(self):
+        return self.user.email
 
     @property
     def confirm_token(self):

--- a/src/django_consent/settings.py
+++ b/src/django_consent/settings.py
@@ -7,6 +7,11 @@ UNSUBSCRIBE_SALT = getattr(
 )
 
 #: You can harden security by adding a different salt in your project's settings
+UNSUBSCRIBE_ALL_SALT = getattr(
+    settings, "CONSENT_UNSUBSCRIBE_SALT", "django-consent-unsubscribe-all"
+)
+
+#: You can harden security by adding a different salt in your project's settings
 CONFIRM_SALT = getattr(settings, "CONSENT_CONFIRM_SALT", "django-consent-confirm")
 
 #: For more information, `django-ratelimit <https://django-ratelimit.readthedocs.io/en/stable/>`__

--- a/src/django_consent/templates/consent/user/unsubscribe/done.html
+++ b/src/django_consent/templates/consent/user/unsubscribe/done.html
@@ -1,6 +1,6 @@
 {% extends "consent/base.html" %}
 {% block consent_content %}
-<p>Your consent has been withdrawn!</p>
+<p>A consent for <strong>{{ consent.email|default:"unknown/deleted" }}</strong> has been withdrawn!</p>
 
 <a href="{% url "consent:unsubscribe_undo" pk=consent.id token=token %}"></a>
 {% endblock %}

--- a/src/django_consent/templates/consent/user/unsubscribe/undo.html
+++ b/src/django_consent/templates/consent/user/unsubscribe/undo.html
@@ -1,4 +1,4 @@
 {% extends "consent/base.html" %}
 {% block consent_content %}
-<p>Your consent optout was undone and consent is re-registered.</p>
+<p>A consent optout was undone and consent is re-registered.</p>
 {% endblock %}

--- a/src/django_consent/templates/consent/user/unsubscribe_all/done.html
+++ b/src/django_consent/templates/consent/user/unsubscribe_all/done.html
@@ -1,0 +1,6 @@
+{% extends "consent/base.html" %}
+{% block consent_content %}
+<p>Your consent for everything associated to the email address <strong>{{ consent.email|default:"unknown/deleted" }}</strong> has been withdrawn!</p>
+
+<a href="{% url "consent:unsubscribe_all_undo" pk=consent.id token=token %}"></a>
+{% endblock %}

--- a/src/django_consent/templates/consent/user/unsubscribe_all/undo.html
+++ b/src/django_consent/templates/consent/user/unsubscribe_all/undo.html
@@ -1,0 +1,4 @@
+{% extends "consent/base.html" %}
+{% block consent_content %}
+<p>Your consent optout for <strong>{{ consent.user.email|default:"unknown/deleted" }}</strong> was undone and consent is re-registered.</p>
+{% endblock %}

--- a/src/django_consent/urls.py
+++ b/src/django_consent/urls.py
@@ -22,4 +22,14 @@ urlpatterns = [
         views.ConsentWithdrawUndoView.as_view(),
         name="unsubscribe_undo",
     ),
+    path(
+        "unsubscribe-all/<int:pk>/<str:token>/",
+        views.ConsentWithdrawAllView.as_view(),
+        name="unsubscribe_all",
+    ),
+    path(
+        "unsubscribe-all/<int:pk>/<str:token>/undo/",
+        views.ConsentWithdrawAllUndoView.as_view(),
+        name="unsubscribe_all_undo",
+    ),
 ]

--- a/src/django_consent/views.py
+++ b/src/django_consent/views.py
@@ -106,6 +106,7 @@ class ConsentWithdrawView(UserConsentActionView):
     template_name = "consent/user/unsubscribe/done.html"
     model = models.UserConsent
     context_object_name = "consent"
+    token_salt = consent_settings.UNSUBSCRIBE_SALT
 
     def action(self, consent):
         consent.optout()
@@ -120,9 +121,45 @@ class ConsentWithdrawUndoView(UserConsentActionView):
     """
 
     template_name = "consent/user/unsubscribe/undo.html"
+    token_salt = consent_settings.UNSUBSCRIBE_SALT
 
     def action(self, consent):
         consent.optouts.all().delete()
+
+
+class ConsentWithdrawAllView(UserConsentActionView):
+    """
+    Withdraws a consent. In the case of a newsletter, it unsubscribes a user
+    from receiving the newsletter.
+
+    Requires a valid link with a token.
+    """
+
+    template_name = "consent/user/unsubscribe_all/done.html"
+    model = models.UserConsent
+    context_object_name = "consent"
+    token_salt = consent_settings.UNSUBSCRIBE_ALL_SALT
+
+    def action(self, consent):
+        consent.optout(is_everything=True)
+
+
+class ConsentWithdrawAllUndoView(UserConsentActionView):
+    """
+    This is related to undoing withdrawal of consent in case that the user
+    clicked the wrong link.
+
+    Requires a valid link
+
+    This only cancels an withdrawal of everything that was related to this
+    particular consent. Another withdrawal can still exist.
+    """
+
+    template_name = "consent/user/unsubscribe_all/undo.html"
+    token_salt = consent_settings.UNSUBSCRIBE_ALL_SALT
+
+    def action(self, consent):
+        consent.optouts.filter(is_everything=True).delete()
 
 
 class ConsentConfirmationReceiveView(UserConsentActionView):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,7 @@
 # Needed for fixtures to be visible in all test_* modules
 from .fixtures import base_consent  # noqa
 from .fixtures import create_user  # noqa
+from .fixtures import many_consents  # noqa
+from .fixtures import many_consents_per_user  # noqa
 from .fixtures import test_password  # noqa
 from .fixtures import user_consent  # noqa

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -58,6 +58,53 @@ def user_consent(base_consent):
 
 
 @pytest.fixture
+def many_consents():
+    """
+    Generate several consents
+    """
+    sources = {
+        "monthly newsletter": "You agree to receiving a newsletter about our activities every month",
+        "vogon poetry": "You agree that the head bureaucrat can send you their poetry randomly",
+        "messages": "Other members can send you a message",
+    }
+    consents = []
+    for name, description in sources.items():
+        consents.append(
+            models.ConsentSource.objects.create(
+                source_name=name,
+                definition=description,
+            )
+        )
+    return consents
+
+
+@pytest.fixture
+def many_consents_per_user(many_consents):
+    """
+    This fixture creates several consents for random users
+    """
+    user_consents = []
+    for source in models.ConsentSource.objects.all():
+        for __ in range(10):
+            user_consents.append(
+                models.UserConsent.capture_email_consent(
+                    source, get_random_email(), require_confirmation=False
+                )
+            )
+        for __ in range(10):
+            user_consents.append(
+                models.UserConsent.capture_email_consent(
+                    source, get_random_email(), require_confirmation=True
+                )
+            )
+
+    return {
+        "many_consents": many_consents,
+        "user_consents": user_consents,
+    }
+
+
+@pytest.fixture
 def test_password():
     return "strong-test-pass"
 


### PR DESCRIPTION
Fixes #2 

We could use a demo of emails, though, where the usage of these links is shown.